### PR TITLE
fix loop_control label

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,9 @@
        | ternary(open_ports_default_ipset_flags, omit)) }}
   with_items: '{{ open_ports_list | mandatory }}'
   loop_control:
-    label:
+    label: '{{ loop_label }}'
+  vars:
+    loop_label:
       port: '{{ item.get("port") | mandatory | string }}'
       protocol: '{{ item.get("protocol", open_ports_default_protocol) }}'
       comment: '{{ item.get("comment", open_ports_default_comment) }}'


### PR DESCRIPTION
```
❯ ansible-playbook ansible/main.yml --tags "open-ports" -i ansible/inventory/test -v
Using /Users/status/work/infra-shards/ansible.cfg as config file
ERROR! The field 'label' is supposed to be a string type, however the incoming data structure is a <class 'ansible.parsing.yaml.objects.AnsibleMapping'>

The error appears to be in '/Users/status/.ansible/roles/open-ports/tasks/main.yml': line 20, column 5, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  loop_control:
    label:
    ^ here
```


> This was a minor bugfix (https://github.com/ansible/ansible/pull/80040), so it wasn't considered a breaking change. label was always intended to just be a string, and the fact that that wasn't validated correctly was a bug.

https://github.com/ansible/ansible/issues/81028#issuecomment-1586234833